### PR TITLE
FIX: Relax framework requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "silverstripe-module",
   "require": {
     "php": ">=5.6",
-    "silverstripe/framework": "4.0.x-dev",
+"silverstripe/framework": "^4.0.0-beta4",
     "silverstripe/graphql": "0.2.*",
     "lcobucci/jwt": "^3.2"
   },


### PR DESCRIPTION
This will let this module work with RCs, stables, and the last beta, which should be fine.